### PR TITLE
qrerun and preemption issue

### DIFF
--- a/src/scheduler/job_info.cpp
+++ b/src/scheduler/job_info.cpp
@@ -973,6 +973,8 @@ query_job(struct batch_status *job, server_info *sinfo, resource_resv *prev_job,
 				resresv->nspec_arr = NULL;
 				free(resresv->ninfo_arr);
 				resresv->ninfo_arr = NULL;
+				free_selspec(resresv->execselect);
+				resresv->execselect = NULL;
 			}
 		} else if (!strcmp(attrp->name, ATTR_substate)) {
 			if (!strcmp(attrp->value, SUSP_BY_SCHED_SUBSTATE))

--- a/src/scheduler/job_info.cpp
+++ b/src/scheduler/job_info.cpp
@@ -2580,6 +2580,7 @@ dup_job_info(job_info *ojinfo, queue_info *nqinfo, server_info *nsinfo)
 	njinfo->stime = ojinfo->stime;
 	njinfo->preempt = ojinfo->preempt;
 	njinfo->preempt_status = ojinfo->preempt_status;
+	njinfo->time_preempted = ojinfo->time_preempted;
 	njinfo->peer_sd = ojinfo->peer_sd;
 	njinfo->job_id = ojinfo->job_id;
 	njinfo->est_start_time = ojinfo->est_start_time;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
2 Problems - 
When a running job is issues a qrerun, execselect of the job is not freed. This results in job running with same execselect.
When a job is preempted it gets time_preempted set on it, but in dup_job_info its not copied. Now that scheduler runs main sched loop on a duped universe, it does not sort preempted jobs up top unless this variable is set on the suplicated jobs.

#### Describe Your Change
Added a free when job moves from running to non-running.
Assigned time_preempted in dup_job_info.

#### Link to Design Doc



#### Attach Test and Valgrind Logs/Output
Description: Tests from given sources on platforms UBUNTU1804, SUSE15, UBUNTU1604, CENTOS8, RHEL8, CENTOS7, RHEL7, SLES12, SLES15, WIN2K16
Platforms: UBUNTU1804,SUSE15,UBUNTU1604,CENTOS8,RHEL8,CENTOS7,RHEL7,SLES12,SLES15,WIN2K16
Profile: regression
|ID|TOTAL|FAIL|ERROR|TIMEDOUT|SKIP|PASS|
|--|--|--|--|--|--|--|
|6093|3990|50|52|0|15|3873|


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
