### PR TITLE
Fixed some bugs

### DIFF
--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -577,6 +577,7 @@ struct job_info
 	unsigned is_provisioning:1;	/* job is provisioning */
 	unsigned is_preempted:1;	/* job is preempted */
 	unsigned topjob_ineligible:1;	/* Job is ineligible to be a top job */
+	bool no_fairshare : 1;		/* Entity is not in the resource_group file */
 
 	char *job_name;			/* job name attribute (qsub -N) */
 	char *svr_inst_id;

--- a/src/scheduler/node_info.cpp
+++ b/src/scheduler/node_info.cpp
@@ -331,7 +331,6 @@ query_node_info(struct batch_status *node, server_info *sinfo, node_info *ninfo)
 
 	if (ninfo == NULL) {
 		ninfo = new node_info(node->name);
-		ninfo->rank = get_sched_rank();
 
 		ninfo->server = sinfo;
 	}
@@ -578,6 +577,7 @@ node_info::node_info(const char *nname): name(nname)
 #endif
 	this->partition = NULL;
 	this->np_arr = NULL;
+	this->rank = get_sched_rank();
 }
 
 /**
@@ -5344,7 +5344,7 @@ sim_exclhost_func(timed_event *te, void *arg1, void *arg2)
 	resresv = (resource_resv*) arg1;
 	ninfo = (node_info*) arg2;
 	future_resresv = (resource_resv*) te->event_ptr;
-	if (find_nspec_by_rank(future_resresv->nspec_arr, ninfo->rank) ==NULL)
+	if (find_nspec_by_rank(future_resresv->nspec_arr, ninfo->rank) == NULL)
 		return 0; /* event does not affect the node */
 
 	if (is_exclhost(future_resresv->place_spec, ninfo->sharing) ||

--- a/src/scheduler/resource_resv.cpp
+++ b/src/scheduler/resource_resv.cpp
@@ -2509,7 +2509,7 @@ in_runnable_state(resource_resv *resresv)
 	if (resresv == NULL)
 		return 0;
 
-	if (resresv->is_job && resresv->job !=NULL) {
+	if (resresv->is_job && resresv->job != NULL) {
 		if (resresv->job->is_array) {
 			if (range_next_value(resresv->job->queued_subjobs, -1) >= 0 ) {
 				if (resresv->job->is_begin || resresv->job->is_queued)

--- a/src/scheduler/sort.cpp
+++ b/src/scheduler/sort.cpp
@@ -722,9 +722,6 @@ node_sort_cmp(const void *vp1, const void *vp2, struct sort_info *si, enum sort_
 			break;
 	}
 
-	if (v1 == v2)
-		return 0;
-
 	if (si->order == ASC) {
 		if (v1 < v2)
 			return -1;
@@ -742,10 +739,11 @@ node_sort_cmp(const void *vp1, const void *vp2, struct sort_info *si, enum sort_
 		else if (v1 > v2)
 			return -1;
 		else {
+			// Always sort rank in ascending order so if all things are equal, nodes are sorted in pbsnodes order
 			if (rank1 < rank2)
-				return 1;
-			else
 				return -1;
+			else
+				return 1;
 		}
 	}
 }

--- a/test/tests/functional/pbs_soft_walltime.py
+++ b/test/tests/functional/pbs_soft_walltime.py
@@ -997,7 +997,7 @@ e.accept()
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 
         self.logger.info("Wait till the soft_walltime is extended once")
-        time.sleep(9)
+        time.sleep(11)
         self.server.manager(MGR_CMD_SET, SERVER, {'scheduling': 'True'})
 
         self.server.expect(JOB, {'estimated.soft_walltime': 8}, op=GT,


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Fixed the following:
* fairshare_enforce_no_shares was broken because we would set job->can_not_run in query_jobs(), but the check if it was in a runnable state in query_queues() and turn it back off.  I fixed this by adding a bit no_fairshares on job_info which is checked to see if we should unset can_not_run.  The benefit of this is we only have to set it once.
* in query_jobs() we'd set the local selectspec and only set it on the job if resresv->nspec_arr was not NULL.  This should have been selectspec != NULL.
* in query_job() when going from running to not-running, we need to not unset nspec_arr and ninfo_arr if we're being suspended.  We need to keep them if the job is being suspended.
* ninfo->rank used to be set in query_nodes().  I moved it into the node_info constructor.  This will waste some ranks when nodes are dup'd, but that should be OK.
* in query_queues, we used to unset can_not_run after we called query_jobs().  I moved this before query_jobs().  
* If all other things are equal, sort nodes in pbsnodes order (to match the perl test's expectations).
* Updated soft walltime test race condition